### PR TITLE
Push buffer up one stack frame

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -13,7 +13,7 @@ use std::io::Read;
 use std::process::Command;
 use std::process::Stdio;
 
-fn getpwuid() -> libc::passwd {
+fn getpwuid(buffer: &mut [i8;16384]) -> libc::passwd {
 	let mut pwent = libc::passwd {
 		pw_name: null_mut(),
 		pw_passwd: null_mut(),
@@ -24,11 +24,10 @@ fn getpwuid() -> libc::passwd {
 		pw_shell: null_mut(),
 	};
 	let mut pwentp = null_mut();
-	let mut buffer = [0i8;16384]; // from the man page
 
 	unsafe {
 		libc::getpwuid_r(libc::geteuid(), &mut pwent, &mut buffer[0],
-			16384, &mut pwentp);
+			buffer.len(), &mut pwentp);
 	}
 
 	pwent
@@ -50,13 +49,15 @@ fn ptr_to_string(name: *mut i8) -> String {
 
 #[cfg(not(target_os = "windows"))]
 pub fn username() -> String {
-	let pwent = getpwuid();
+	let mut buffer = [0i8;16384]; // from the man page
+	let pwent = getpwuid(&mut buffer);
 
 	ptr_to_string(pwent.pw_name)
 }
 
 pub fn realname() -> String {
-	let pwent = getpwuid();
+	let mut buffer = [0i8;16384]; // from the man page
+	let pwent = getpwuid(&mut buffer);
 
 	ptr_to_string(pwent.pw_gecos)
 }


### PR DESCRIPTION
Declaring the buffer in getpwuid and then returning pwent, will cause
pwent to point to memory that happens to exist, but is not guaranteed
to be valid.