### PR TITLE
Trim trailing zero from GetUserNameW

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,7 +15,8 @@ pub fn username() -> String {
 		GetUserNameW(&mut name[0], &mut size);
 	}
 	
-	String::from_utf16_lossy(&name[..size])
+	if size == 0 { String::new() }
+	else { String::from_utf16_lossy(&name[..size-1]) }
 }
 
 pub fn realname() -> String {


### PR DESCRIPTION
GetUserNameW returns the size including the terminating zero. We don't want to
include that in our result.