### PR TITLE
Typo fix in case of OS not being detected

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -101,7 +101,7 @@ pub fn os() -> String {
 		}
 	}
 
-	return "uknown".to_string();
+	return "unknown".to_string();
 }
 
 #[inline(always)]


### PR DESCRIPTION
OS output contained a spelling mistake in case of not being detected, this is fixed now